### PR TITLE
Primary Key Sequence - database setup 

### DIFF
--- a/lib/tasks/csv_load.rake
+++ b/lib/tasks/csv_load.rake
@@ -8,6 +8,9 @@ namespace :csv_load do
       Customer.create(row.to_hash)
       p row
     end
+      table = 'customers'
+      ai_val = 1001
+      ActiveRecord::Base.connection.execute("ALTER SEQUENCE #{table}_id_seq RESTART WITH #{ai_val}")
   end
 
   desc "imports invoices from a csv file"
@@ -17,6 +20,9 @@ namespace :csv_load do
       Invoice.create(row.to_hash)
       p row
     end
+      table = 'invoices'
+      ai_val = 901
+      ActiveRecord::Base.connection.execute("ALTER SEQUENCE #{table}_id_seq RESTART WITH #{ai_val}")
   end
 
   desc "imports items from a csv file"
@@ -26,6 +32,9 @@ namespace :csv_load do
       Item.create(row.to_hash)
       p row
     end
+      table = 'items'
+      ai_val = 2484
+      ActiveRecord::Base.connection.execute("ALTER SEQUENCE #{table}_id_seq RESTART WITH #{ai_val}")
   end
 
   desc "imports merchants from a csv file"
@@ -35,6 +44,9 @@ namespace :csv_load do
       Merchant.create(row.to_hash)
       p row
     end
+      table = 'merchants'
+      ai_val = 101
+      ActiveRecord::Base.connection.execute("ALTER SEQUENCE #{table}_id_seq RESTART WITH #{ai_val}")
   end
 
   desc "imports transactions from a csv file"
@@ -44,6 +56,9 @@ namespace :csv_load do
       Transaction.create(row.to_hash)
       p row
     end
+      table = 'transactions'
+      ai_val = 1045
+      ActiveRecord::Base.connection.execute("ALTER SEQUENCE #{table}_id_seq RESTART WITH #{ai_val}")
   end
 
   desc "imports invoice_items from a csv file"
@@ -53,6 +68,9 @@ namespace :csv_load do
       InvoiceItem.create(row.to_hash)
       p row
     end
+      table = 'invoice_items'
+      ai_val = 4015
+      ActiveRecord::Base.connection.execute("ALTER SEQUENCE #{table}_id_seq RESTART WITH #{ai_val}")
   end
 
   desc 'import all csv files'


### PR DESCRIPTION
resets the primary key sequence for each table after the data is seeded by:

`table name`, ie "customers", `ai_val ` is equal to number of rows`/ids that particular table should have

ActiveRecord method to alter the sequence to restart with the `ai_val `

`  ActiveRecord::Base.connection.execute("ALTER SEQUENCE #{table}_id_seq RESTART WITH #{ai_val}")
`

does this for each csv file in the rake task, starting w/customers:
```
desc “imports customers from a csv file”
  task customers: :environment do
    file = ‘db/data/customers.csv’
    CSV.foreach(file, headers: true, header_converters: :symbol) do |row|
      Customer.create([row.to](http://row.to/)_hash)
      p row
    end
     table = 'customers'
      ai_val = 1001 
      ActiveRecord:Base.connection.execute("ALTER SEQUENCE #{table}_id_seq RESTART WITH #{ai_val}")
  end
```